### PR TITLE
Add cross version support for Scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 *.log
+.bsp
 
 # sbt specific
 .cache

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,19 @@
 val dependencies = Seq(
-  "org.scalanlp" %% "breeze" % "0.11.2",
-  "org.scalanlp" %% "breeze-natives" % "0.11.2",
-  "net.debasishg" %% "redisclient" % "3.0",
-  "com.lambdaworks" %% "jacks" % "2.3.3",
-  "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test",
+  "org.scalanlp" %% "breeze" % "1.0",
+  "org.scalanlp" %% "breeze-natives" % "1.0",
+  "net.debasishg" %% "redisclient" % "3.40",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.0",
+  "org.scalatest" %% "scalatest" % "3.2.10" % "test",
   "com.orange.redis-embedded" % "embedded-redis" % "0.6" % "test"
 )
 
 lazy val root = (project in file(".")).settings(
   name := "lsh-scala",
   organization := "io.krom",
-  version := "0.1",
-  scalaVersion := "2.11.7",
+  version := "0.1-SNAPSHOT",
+  scalaVersion := "2.12.7",
+  crossScalaVersions := Seq("2.11.12", "2.12.7"),
   libraryDependencies ++= dependencies,
   parallelExecution in Test := false,
   publishTo := {
@@ -26,23 +28,23 @@ lazy val root = (project in file(".")).settings(
   sonatypeProfileName := "io.krom",
   pomIncludeRepository := { _ => false },
   pomExtra := (<url>https://github.com/barneygovan/lsh-scala</url>
-      <licenses>
-        <license>
-          <name>Apache 2.0 License</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-      <scm>
-        <connection>scm:git:github.com/barneygovan/lsh-scala.git</connection>
-        <developerConnection>scm:git:git@github.com:barneygovan/lsh-scala.git</developerConnection>
-        <url>github.com/barneygovan/lsh-scala.git</url>
-      </scm>
-      <developers>
-        <developer>
-          <id>barneygovan</id>
-          <name>Barney Govan</name>
-          <url>https://github.com/barneygovan</url>
-        </developer>
-      </developers>)
+        <licenses>
+            <license>
+                <name>Apache 2.0 License</name>
+                <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                <distribution>repo</distribution>
+            </license>
+        </licenses>
+        <scm>
+            <connection>scm:git:github.com/barneygovan/lsh-scala.git</connection>
+            <developerConnection>scm:git:git@github.com:barneygovan/lsh-scala.git</developerConnection>
+            <url>github.com/barneygovan/lsh-scala.git</url>
+        </scm>
+        <developers>
+            <developer>
+                <id>barneygovan</id>
+                <name>Barney Govan</name>
+                <url>https://github.com/barneygovan</url>
+            </developer>
+        </developers>)
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=1.4.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+//addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.1")
+//addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/src/main/scala/io/krom/lsh/InMemoryLshTable.scala
+++ b/src/main/scala/io/krom/lsh/InMemoryLshTable.scala
@@ -7,7 +7,7 @@ object InMemoryLshTable {
   def createTables(
       numTables: Int,
       prefix: Option[String] = None
-  ): IndexedSeq[NewLshTable] = {
+  ): IndexedSeq[LshTable] = {
     for {
       _ <- 1 to numTables
     } yield new InMemoryLshTable(prefix)
@@ -15,7 +15,7 @@ object InMemoryLshTable {
 }
 
 class InMemoryLshTable(override protected val prefix: Option[String] = None)
-    extends NewLshTable {
+    extends LshTable {
 
   private val index = new HashMap[String, HashSet[String]]()
   private val table = new HashMap[String, LshEntry]()

--- a/src/main/scala/io/krom/lsh/InMemoryLshTable.scala
+++ b/src/main/scala/io/krom/lsh/InMemoryLshTable.scala
@@ -1,64 +1,52 @@
 package io.krom.lsh
 
-import breeze.linalg.DenseVector
-
-import collection.mutable.HashMap
-import collection.mutable.HashSet
 import scala.collection.mutable
-
-class InMemoryLshTable(prefix: Option[String] = None) extends LshTable(prefix) {
-
-  private val index = new HashMap[String, HashSet[String]]()
-  private val table =
-    new HashMap[String, (String, String, DenseVector[Double])]()
-
-  override def put(hash: String, label: String, point: DenseVector[Double]) = {
-    val key = createKey(hash)
-    val value = (label, key, point)
-
-    if (!index.keySet.contains(key)) index(key) = new HashSet[String]()
-    index(key) += label
-    table(label) = value
-  }
-
-  override def update(
-      hash: String,
-      label: String,
-      point: DenseVector[Double]
-  ) = {
-    val key = createKey(hash)
-    val (_, oldKey, _) = table(label)
-    val newValue = (label, key, point)
-
-    table(label) = newValue
-    if (key != oldKey) {
-      index(oldKey) -= label
-      if (!index.keySet.contains(key))
-        index(key) = new mutable.HashSet[String]()
-      index(key) += label
-    }
-  }
-
-  override def get(
-      hash: String
-  ): List[(String, String, DenseVector[Double])] = {
-    val key = createKey(hash)
-
-    val items = if (index.keySet.contains(key)) index(key) else new HashSet()
-
-    (for {
-      item <- items
-    } yield table(item)).toList
-  }
-}
+import scala.collection.mutable.{HashMap, HashSet}
 
 object InMemoryLshTable {
   def createTables(
       numTables: Int,
       prefix: Option[String] = None
-  ): IndexedSeq[LshTable] = {
+  ): IndexedSeq[NewLshTable] = {
     for {
       _ <- 1 to numTables
     } yield new InMemoryLshTable(prefix)
+  }
+}
+
+class InMemoryLshTable(override protected val prefix: Option[String] = None)
+    extends NewLshTable {
+
+  private val index = new HashMap[String, HashSet[String]]()
+  private val table = new HashMap[String, LshEntry]()
+
+  override def put(entry: LshEntry): Unit = {
+    val value = entry.copy(hash = createKey(entry.hash))
+
+    if (!index.keySet.contains(value.hash))
+      index(value.hash) = new HashSet[String]()
+    index(value.hash) += entry.label
+    table(value.label) = value
+  }
+
+  override def update(entry: LshEntry): Unit = {
+    val oldValue = table(entry.label)
+    val newValue = entry.copy(hash = createKey(entry.hash))
+
+    table(entry.label) = newValue
+    if (newValue.hash != oldValue.hash) {
+      index(oldValue.hash) -= entry.label
+      if (!index.keySet.contains(newValue.hash))
+        index(newValue.hash) = new mutable.HashSet[String]()
+      index(newValue.hash) += entry.label
+    }
+  }
+
+  override def get(hash: String): List[LshEntry] = {
+    val key = createKey(hash)
+    val items = if (index.keySet.contains(key)) index(key) else new HashSet()
+    (for {
+      item <- items
+    } yield table(item)).toList
   }
 }

--- a/src/main/scala/io/krom/lsh/Lsh.scala
+++ b/src/main/scala/io/krom/lsh/Lsh.scala
@@ -4,17 +4,16 @@ import breeze.linalg.{DenseMatrix, DenseVector}
 import breeze.stats.distributions.Gaussian
 import io.krom.lsh.DistanceFunction.euclideanDistance
 
-import scala.collection.immutable.HashMap
 import scala.collection.mutable.{HashSet, PriorityQueue}
 
 class Lsh(
-    tables: IndexedSeq[LshTable],
+    newTables: IndexedSeq[NewLshTable],
     projections: IndexedSeq[DenseMatrix[Double]]
 ) {
 
   def store(point: DenseVector[Double], label: String) {
     for ((key, i) <- calculateHashes(point).zipWithIndex) {
-      tables(i).put(key, label, point)
+      newTables(i).put(LshEntry(key, label, point))
     }
   }
 
@@ -25,30 +24,23 @@ class Lsh(
         euclideanDistance
   ): IndexedSeq[(String, Double)] = {
 
-    def isLabelNew(label: String, labelSet: HashSet[String]): Boolean = {
-      if (labelSet.contains(label)) {
-        false
-      } else {
-        labelSet += label
-        true
-      }
+    val labelSet = new HashSet[String]()
+
+    val results2 = {
+      calculateHashes(point).zipWithIndex
+        .map(t => newTables(t._2).get(t._1))
+        .flatMap(x => x.filter(z => isLabelNew(z.label, labelSet)))
+        .map(x => (x.label, distanceFunction(point, x.point)))
     }
 
-    val labelSet = new HashSet[String]()
-    val results = for {
-      (key, i) <- calculateHashes(point).zipWithIndex
-      items = tables(i).get(key)
-      (label, _, otherPoint) <- items if isLabelNew(label, labelSet)
-    } yield (label, distanceFunction(point, otherPoint))
-
     val heap = new PriorityQueue[(String, Double)]()(Ordering.by(_._2))
-    heap ++= results
+    heap ++= results2
     heap.take(maxItems).toIndexedSeq
   }
 
   def update(point: DenseVector[Double], label: String) {
     for ((key, i) <- calculateHashes(point).zipWithIndex) {
-      tables(i).update(key, label, point)
+      newTables(i).update(LshEntry(key, label, point))
     }
   }
 
@@ -62,6 +54,15 @@ class Lsh(
       .toArray
       .mkString
   }
+
+  private def isLabelNew(label: String, labelSet: HashSet[String]): Boolean = {
+    if (labelSet.contains(label)) {
+      false
+    } else {
+      labelSet += label
+      true
+    }
+  }
 }
 
 object Lsh {
@@ -71,7 +72,7 @@ object Lsh {
       numTables: Int,
       prefix: Option[String] = None,
       projectionsFilename: Option[String] = None,
-      storageConfig: Option[HashMap[String, String]] = None
+      storageConfig: Option[Map[String, String]] = None
   ): Lsh = {
 
     val tables = storageConfig match {

--- a/src/main/scala/io/krom/lsh/Lsh.scala
+++ b/src/main/scala/io/krom/lsh/Lsh.scala
@@ -7,13 +7,13 @@ import io.krom.lsh.DistanceFunction.euclideanDistance
 import scala.collection.mutable.{HashSet, PriorityQueue}
 
 class Lsh(
-    newTables: IndexedSeq[NewLshTable],
-    projections: IndexedSeq[DenseMatrix[Double]]
+  tables: IndexedSeq[LshTable],
+  projections: IndexedSeq[DenseMatrix[Double]]
 ) {
 
   def store(point: DenseVector[Double], label: String) {
     for ((key, i) <- calculateHashes(point).zipWithIndex) {
-      newTables(i).put(LshEntry(key, label, point))
+      tables( i ).put( LshEntry( key, label, point ) )
     }
   }
 
@@ -28,7 +28,7 @@ class Lsh(
 
     val results2 = {
       calculateHashes(point).zipWithIndex
-        .map(t => newTables(t._2).get(t._1))
+        .map(t => tables( t._2 ).get( t._1 ) )
         .flatMap(x => x.filter(z => isLabelNew(z.label, labelSet)))
         .map(x => (x.label, distanceFunction(point, x.point)))
     }
@@ -40,7 +40,7 @@ class Lsh(
 
   def update(point: DenseVector[Double], label: String) {
     for ((key, i) <- calculateHashes(point).zipWithIndex) {
-      newTables(i).update(LshEntry(key, label, point))
+      tables( i ).update( LshEntry( key, label, point ) )
     }
   }
 

--- a/src/main/scala/io/krom/lsh/LshEntry.scala
+++ b/src/main/scala/io/krom/lsh/LshEntry.scala
@@ -1,0 +1,5 @@
+package io.krom.lsh
+
+import breeze.linalg.DenseVector
+
+case class LshEntry(hash: String, label: String, point: DenseVector[Double])

--- a/src/main/scala/io/krom/lsh/LshTable.scala
+++ b/src/main/scala/io/krom/lsh/LshTable.scala
@@ -5,7 +5,9 @@ import breeze.linalg.DenseVector
 abstract class LshTable(prefix: Option[String] = None) {
 
   def put(hash: String, label: String, point: DenseVector[Double])
+
   def get(hash: String): List[(String, String, DenseVector[Double])]
+
   def update(hash: String, label: String, point: DenseVector[Double])
 
   protected def createKey(hash: String): String = {
@@ -14,4 +16,23 @@ abstract class LshTable(prefix: Option[String] = None) {
       case Some(p) => p + ":" + hash
     }
   }
+}
+
+trait NewLshTable {
+
+  protected val prefix: Option[String]
+
+  def put(entry: LshEntry): Unit
+
+  def update(entry: LshEntry)
+
+  def get(hash: String): List[LshEntry]
+
+  protected def createKey(hash: String): String = {
+    prefix match {
+      case None    => hash
+      case Some(p) => p + ":" + hash
+    }
+  }
+
 }

--- a/src/main/scala/io/krom/lsh/LshTable.scala
+++ b/src/main/scala/io/krom/lsh/LshTable.scala
@@ -1,24 +1,6 @@
 package io.krom.lsh
 
-import breeze.linalg.DenseVector
-
-abstract class LshTable(prefix: Option[String] = None) {
-
-  def put(hash: String, label: String, point: DenseVector[Double])
-
-  def get(hash: String): List[(String, String, DenseVector[Double])]
-
-  def update(hash: String, label: String, point: DenseVector[Double])
-
-  protected def createKey(hash: String): String = {
-    prefix match {
-      case None    => hash
-      case Some(p) => p + ":" + hash
-    }
-  }
-}
-
-trait NewLshTable {
+trait LshTable {
 
   protected val prefix: Option[String]
 

--- a/src/main/scala/io/krom/lsh/RedisLshTable.scala
+++ b/src/main/scala/io/krom/lsh/RedisLshTable.scala
@@ -1,54 +1,68 @@
 package io.krom.lsh
 
-import breeze.linalg.DenseVector
-import com.lambdaworks.jacks.JacksMapper
 import com.redis.RedisClient
 
-import scala.collection.immutable.HashMap
+object RedisLshTable {
+  def createTables(
+      numTables: Int,
+      redisConf: Map[String, String],
+      prefix: Option[String] = None
+  ): IndexedSeq[NewLshTable] = {
+    val redisHost =
+      if (redisConf.contains("host")) redisConf("host") else "localhost"
+    val redisPort =
+      if (redisConf.contains("port")) Integer.parseInt(redisConf("port"))
+      else 6379
+    val serializer =
+      if (redisConf.contains("serializer")) redisConf("serializer") else "json"
 
-class RedisLshTable(redisdb: RedisClient, prefix: Option[String] = None)
-    extends LshTable(prefix) {
+    (0 to numTables).map(i => {
+      serializer match {
+        case "json" =>
+          new RedisLshTable(new RedisClient(redisHost, redisPort, i))
+            with JsonSerialization
+        case other =>
+          throw new IllegalArgumentException(
+            s"${other} is not a supported serialization format"
+          ) //TODO - would like to add support for java, protobuf, etc...
+      }
+    })
+  }
 
-  override def put(
-      hash: String,
-      label: String,
-      point: DenseVector[Double]
-  ): Unit = {
-    val key = createKey(hash)
-    val value = (label, key, point.toArray)
+}
 
+abstract class RedisLshTable(
+    redisdb: RedisClient,
+    val prefix: Option[String] = None
+) extends NewLshTable
+    with Serialization {
+
+  override def put(entry: LshEntry): Unit = {
+    val key = createKey(entry.hash)
     redisdb.pipeline { pipe =>
-      pipe.sadd(key, label)
-      pipe.set(label, JacksMapper.writeValueAsString(value))
+      pipe.sadd(key, entry.label)
+      pipe.set(entry.label, serialize(entry))
     }
   }
 
-  override def update(
-      hash: String,
-      label: String,
-      point: DenseVector[Double]
-  ): Unit = {
-    val key = createKey(hash)
+  override def update(entry: LshEntry): Unit = {
+    val key = createKey(entry.hash)
 
-    val item = redisdb.get(label) match {
-      case None => return
-      case Some(x: String) =>
-        JacksMapper.readValue[(String, String, Array[Double])](x)
+    val oldEntry = redisdb.get(entry.label) match {
+      case None       => return
+      case Some(data) => deserialize(data.getBytes)
     }
-    val oldKey = item._2
-
-    val value = (label, key, point.toArray)
+    val oldKey = oldEntry.hash
 
     redisdb.pipeline { pipe =>
-      pipe.set(label, JacksMapper.writeValueAsString(value))
-      if (key != oldKey) pipe.srem(oldKey, label)
-      pipe.sadd(key, label)
+      pipe.set(entry.label, serialize(entry))
+      if (key != oldKey) pipe.srem(oldKey, entry.label)
+      pipe.sadd(key, entry.label)
     }
   }
 
-  override def get(
-      hash: String
-  ): List[(String, String, DenseVector[Double])] = {
+  override def get(hash: String): List[LshEntry] = {
+    import com.redis.serialization.Parse.Implicits.parseByteArray
     val key = createKey(hash)
     val items = redisdb.smembers(key)
 
@@ -59,34 +73,14 @@ class RedisLshTable(redisdb: RedisClient, prefix: Option[String] = None)
       } pipe.get(item.get)
     }
 
-    for {
-      item <- itemDetails.get
-      newItem = item match {
-        case Some(x: String) =>
-          Some(JacksMapper.readValue[(String, String, Array[Double])](x))
+    itemDetails.get
+      .flatMap {
+        case Some(data: Array[Byte]) => Some(deserialize(data))
+        case Some(other) =>
+          throw new UnsupportedOperationException(
+            s"unable to serialize data of ${other.getClass.getCanonicalName}"
+          )
         case None => None
       }
-      if newItem.isDefined
-    } yield (newItem.get._1, newItem.get._2, DenseVector(newItem.get._3))
-  }
-}
-
-object RedisLshTable {
-  def createTables(
-      numTables: Int,
-      redisConf: HashMap[String, String],
-      prefix: Option[String] = None
-  ): IndexedSeq[LshTable] = {
-    val redisHost =
-      if (redisConf.contains("host")) redisConf("host") else "localhost"
-    val redisPort =
-      if (redisConf.contains("port")) Integer.parseInt(redisConf("port"))
-      else 6379
-    for {
-      redisDb <- 0 until numTables
-    } yield new RedisLshTable(
-      new RedisClient(redisHost, redisPort, redisDb),
-      prefix
-    )
   }
 }

--- a/src/main/scala/io/krom/lsh/RedisLshTable.scala
+++ b/src/main/scala/io/krom/lsh/RedisLshTable.scala
@@ -7,7 +7,7 @@ object RedisLshTable {
       numTables: Int,
       redisConf: Map[String, String],
       prefix: Option[String] = None
-  ): IndexedSeq[NewLshTable] = {
+  ): IndexedSeq[LshTable] = {
     val redisHost =
       if (redisConf.contains("host")) redisConf("host") else "localhost"
     val redisPort =
@@ -34,7 +34,7 @@ object RedisLshTable {
 abstract class RedisLshTable(
     redisdb: RedisClient,
     val prefix: Option[String] = None
-) extends NewLshTable
+) extends LshTable
     with Serialization {
 
   override def put(entry: LshEntry): Unit = {

--- a/src/main/scala/io/krom/lsh/Serialization.scala
+++ b/src/main/scala/io/krom/lsh/Serialization.scala
@@ -1,0 +1,59 @@
+package io.krom.lsh
+
+import breeze.linalg.DenseVector
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.{ArrayNode, DoubleNode, ObjectNode}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+import scala.collection.JavaConverters._
+
+trait Serialization {
+
+  def serialize(lsh: LshEntry): Array[Byte]
+
+  def deserialize(data: Array[Byte]): LshEntry
+
+}
+
+trait JsonSerialization extends Serialization {
+
+  List().asJava
+  private lazy val MAPPER: ObjectMapper = {
+    val m = new ObjectMapper()
+    m.registerModule(DefaultScalaModule)
+    m.registerModule(new JavaTimeModule)
+  }
+
+  override def serialize(lsh: LshEntry): Array[Byte] = {
+    MAPPER.writeValueAsString(lsh).getBytes
+  }
+
+  override def deserialize(input: Array[Byte]): LshEntry = {
+    val json = MAPPER.readValue[ObjectNode](input, classOf[ObjectNode])
+    val hash = json.get("hash").textValue()
+    val label = json.get("label").textValue()
+    // custom jackson serialization because `breeze.linalg.DenseVector` is specialized
+    val point: DenseVector[Double] = {
+      val node: ArrayNode =
+        json.get("point").withArray[ArrayNode]("data$mcD$sp")
+      val vector =
+        node
+          .elements()
+          .asScala
+          .flatMap {
+            case node: DoubleNode => Some(node.doubleValue())
+            case other =>
+              throw new IllegalStateException(
+                s"non numeric value found in Array[ Double ] - ${other.toString}"
+              )
+          }
+          .toArray
+      DenseVector(vector)
+
+    }
+
+    LshEntry(hash = hash, label = label, point = point)
+  }
+
+}

--- a/src/test/scala/io/krom/lsh/DistanceFunctionSpec.scala
+++ b/src/test/scala/io/krom/lsh/DistanceFunctionSpec.scala
@@ -1,13 +1,11 @@
 package io.krom.lsh
 
 import breeze.linalg.DenseVector
+import io.krom.lsh.DistanceFunction._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-import org.scalatest.{Matchers, FunSpec}
-
-import DistanceFunction._
-
-class DistanceFunctionSpec extends FunSpec with Matchers {
-
+class DistanceFunctionSpec extends AnyFunSpec with Matchers {
   describe("calculating Euclidean distance score") {
     it(
       "should equal 1 over 1 plus the square root of the sum of the squares of the sides"

--- a/src/test/scala/io/krom/lsh/InMemoryLshTableSpec.scala
+++ b/src/test/scala/io/krom/lsh/InMemoryLshTableSpec.scala
@@ -1,111 +1,95 @@
 package io.krom.lsh
 
 import breeze.linalg.DenseVector
-import org.scalatest.FunSpec
-import org.scalatest.Matchers._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class InMemoryLshTableSpec extends FunSpec {
+class InMemoryLshTableSpec extends AnyFunSpec with Matchers {
 
   describe("put without prefix") {
     it("should return the value just added") {
-
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
-
-      val testKey = "testhashkey"
+      val entry = LshEntry("testhashkey", "point1", DenseVector(0.1, 0.2))
 
       val table = new InMemoryLshTable()
 
-      table.put(testKey, testLabel1, testPoint1)
-      table.get(testKey).length should equal(1)
-      table.get(testKey)(0) should equal(testLabel1, testKey, testPoint1)
+      table.put(entry)
+      table.get(entry.hash).length shouldBe 1
+      table.get(entry.hash).head shouldBe entry
     }
+
     it("should return multiple results when more than one value is added") {
-
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
-      val testPoint2 = DenseVector(0.3, 0.4)
-      val testLabel2 = "point2"
-      val testKey = "testhashkey"
-
       val table = new InMemoryLshTable()
 
-      table.put(testKey, testLabel1, testPoint1)
-      table.put(testKey, testLabel2, testPoint2)
-      table.get(testKey).length should equal(2)
-      val data = table.get(testKey).sortBy(_._1)
-      data(0) should equal(testLabel1, testKey, testPoint1)
-      data(1) should equal(testLabel2, testKey, testPoint2)
+      val entry1 = LshEntry("testhashkey", "point1", DenseVector(0.1, 0.2))
+      val entry2 = LshEntry("testhashkey", "point2", DenseVector(0.3, 0.4))
+
+      table.put(entry1)
+      table.put(entry2)
+
+      table.get(entry1.hash).length should equal(2)
+      val data = table.get(entry1.hash).sortBy(_.hash)
+      data should contain(entry1)
+      data should contain(entry2)
     }
   }
 
   describe("put with prefix") {
     it("should return the value just added") {
-
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
-
-      val testKey = "testhashkey"
       val testPrefix = "testprefix"
 
       val table = new InMemoryLshTable(Some(testPrefix))
 
-      table.put(testKey, testLabel1, testPoint1)
-      table.get(testKey).length should equal(1)
-      table.get(testKey)(0) should equal(
-        testLabel1,
-        testPrefix + ":" + testKey,
-        testPoint1
-      )
+      val input = LshEntry("testhashkey", "point1", DenseVector(0.1, 0.2))
+      table.put(input)
+
+      val expected = input.copy(hash = s"${testPrefix}:${input.hash}")
+
+      table.get(input.hash).length should equal(1)
+      table.get(input.hash).head should equal(expected)
     }
     it("should return multiple results when more than one value is added") {
-
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
-      val testPoint2 = DenseVector(0.3, 0.4)
-      val testLabel2 = "point2"
-      val testKey = "testhashkey"
       val testPrefix = "testPrefix"
-
+      val testKey = "testhashkey"
       val table = new InMemoryLshTable(Some(testPrefix))
 
-      table.put(testKey, testLabel1, testPoint1)
-      table.put(testKey, testLabel2, testPoint2)
-      table.get(testKey).length should equal(2)
-      val data = table.get(testKey).sortBy(_._1)
-      data(0) should equal(testLabel1, testPrefix + ":" + testKey, testPoint1)
-      data(1) should equal(testLabel2, testPrefix + ":" + testKey, testPoint2)
+      val entry1 = LshEntry(testKey, "point1", DenseVector(0.1, 0.2))
+      val entry2 = LshEntry(testKey, "point2", DenseVector(0.3, 0.4))
+      table.put(entry1)
+      table.put(entry2)
+
+      table.get(entry1.hash).length should equal(2)
+
+      val expected1 = entry1.copy(hash = s"${testPrefix}:${testKey}")
+      val expected2 = entry2.copy(hash = s"${testPrefix}:${testKey}")
+      val data = table.get(testKey).sortBy(_.hash)
+      data should contain(expected1)
+      data should contain(expected2)
     }
   }
 
   describe("update") {
     it("should change the value previously stored") {
-
-      val testPoint = DenseVector(0.1, 0.2)
-      val testUpdatedPoint = DenseVector(0.3, 0.4)
-      val testKey1 = "testkey1"
-      val testKey2 = "testkey2"
-      val testPrefix = "testPrefix"
-      val testLabel = "testData"
-
+      val testPrefix = "testprefix"
       val table = new InMemoryLshTable(Some(testPrefix))
 
-      table.put(testKey1, testLabel, testPoint)
-      table.get(testKey1).length should equal(1)
-      table.get(testKey1)(0) should equal(
-        testLabel,
-        testPrefix + ":" + testKey1,
-        testPoint
-      )
+      val input = LshEntry("testkey1", "testData", DenseVector(0.1, 0.2))
+      table.put(input)
+      val expectedPut = input.copy(hash = s"${testPrefix}:${input.hash}")
+      val putResults = table.get(input.hash)
+      putResults.length should equal(1)
+      putResults.head should equal(expectedPut)
 
-      table.update(testKey2, testLabel, testUpdatedPoint)
-      table.get(testKey1).length should equal(0)
-      table.get(testKey2).length should equal(1)
-      table.get(testKey2)(0) should equal(
-        testLabel,
-        testPrefix + ":" + testKey2,
-        testUpdatedPoint
-      )
+      val update = LshEntry("testkey2", input.label, DenseVector(0.3, 0.3))
+      table.update(update)
+
+      table
+        .get(input.hash)
+        .length shouldBe 0 // make sure the original value has been updated
+
+      val expectedUpdate = update.copy(hash = s"${testPrefix}:${update.hash}")
+      val updateResults = table.get(update.hash)
+      updateResults.length shouldBe 1
+      updateResults.head shouldBe expectedUpdate
     }
   }
 }

--- a/src/test/scala/io/krom/lsh/LshSpec.scala
+++ b/src/test/scala/io/krom/lsh/LshSpec.scala
@@ -1,14 +1,14 @@
 package io.krom.lsh
 
 import breeze.linalg.{DenseMatrix, DenseVector}
-import org.scalatest.{Matchers, FunSpec}
-
-import DistanceFunction._
+import io.krom.lsh.DistanceFunction._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import redis.embedded.RedisServer
 
 import scala.collection.immutable.HashMap
 
-class LshSpec extends FunSpec with Matchers {
+class LshSpec extends AnyFunSpec with Matchers {
 
   describe("initializing projections") {
     it("should load from a file if filename is specified") {

--- a/src/test/scala/io/krom/lsh/RedisLshTableSpec.scala
+++ b/src/test/scala/io/krom/lsh/RedisLshTableSpec.scala
@@ -1,151 +1,116 @@
 package io.krom.lsh
 
 import breeze.linalg.DenseVector
-import org.scalatest.{Matchers, FunSpec}
 import com.redis.RedisClient
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import redis.embedded.RedisServer
 
-class RedisLshTableSpec extends FunSpec with Matchers {
+class RedisLshTableSpec
+    extends AnyFunSpec
+    with Matchers
+    with BeforeAndAfterEach {
+
+  val redisPort: Int = 1234
+  val redisDb: Int = 5
+  val redisServer = {
+    val server = new RedisServer(redisPort)
+    server.start()
+  }
+
+  override def beforeEach() = {
+    newClient().flushdb
+  }
+
   describe("put without prefix") {
     it("should return the value just added") {
+      val entry = LshEntry("testhashkey", "point1", DenseVector(0.1, 0.2))
 
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
+      val table = new RedisLshTable(newClient) with JsonSerialization
 
-      val testKey = "testhashkey"
-
-      val redisServer = new RedisServer(1234)
-      redisServer.start()
-
-      val redis = new RedisClient("localhost", 1234, 5)
-      redis.flushdb
-
-      val table = new RedisLshTable(redis)
-
-      table.put(testKey, testLabel1, testPoint1)
-      table.get(testKey).length should equal(1)
-      table.get(testKey)(0) should equal(testLabel1, testKey, testPoint1)
-
-      redisServer.stop()
+      table.put(entry)
+      table.get(entry.hash).length shouldBe 1
+      table.get(entry.hash).head shouldBe entry
     }
+
     it("should return multiple results when more than one value is added") {
+      val table = new RedisLshTable(newClient) with JsonSerialization
 
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
-      val testPoint2 = DenseVector(0.3, 0.4)
-      val testLabel2 = "point2"
-      val testKey = "testhashkey"
+      val entry1 = LshEntry("testhashkey", "point1", DenseVector(0.1, 0.2))
+      val entry2 = LshEntry("testhashkey", "point2", DenseVector(0.3, 0.4))
 
-      val redisServer = new RedisServer(1234)
-      redisServer.start()
+      table.put(entry1)
+      table.put(entry2)
 
-      val redis = new RedisClient("localhost", 1234, 5)
-      redis.flushdb
-
-      val table = new RedisLshTable(redis)
-
-      table.put(testKey, testLabel1, testPoint1)
-      table.put(testKey, testLabel2, testPoint2)
-      table.get(testKey).length should equal(2)
-      val data = table.get(testKey).sortBy(_._1)
-      data(0) should equal(testLabel1, testKey, testPoint1)
-      data(1) should equal(testLabel2, testKey, testPoint2)
-
-      redisServer.stop()
+      table.get(entry1.hash).length should equal(2)
+      val data = table.get(entry1.hash).sortBy(_.hash)
+      data should contain(entry1)
+      data should contain(entry2)
     }
   }
 
   describe("put with prefix") {
     it("should return the value just added") {
-
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
-
-      val testKey = "testhashkey"
       val testPrefix = "testprefix"
 
-      val redisServer = new RedisServer(1234)
-      redisServer.start()
+      val table = new InMemoryLshTable(Some(testPrefix))
 
-      val redis = new RedisClient("localhost", 1234, 5)
-      redis.flushdb
+      val input = LshEntry("testhashkey", "point1", DenseVector(0.1, 0.2))
+      table.put(input)
 
-      val table = new RedisLshTable(redis, Some(testPrefix))
+      val expected = input.copy(hash = s"${testPrefix}:${input.hash}")
 
-      table.put(testKey, testLabel1, testPoint1)
-      table.get(testKey).length should equal(1)
-      table.get(testKey)(0) should equal(
-        testLabel1,
-        testPrefix + ":" + testKey,
-        testPoint1
-      )
-
-      redisServer.stop()
+      table.get(input.hash).length should equal(1)
+      table.get(input.hash).head should equal(expected)
     }
     it("should return multiple results when more than one value is added") {
-
-      val testPoint1 = DenseVector(0.1, 0.2)
-      val testLabel1 = "point1"
-      val testPoint2 = DenseVector(0.3, 0.4)
-      val testLabel2 = "point2"
-      val testKey = "testhashkey"
       val testPrefix = "testPrefix"
+      val testKey = "testhashkey"
+      val table = new InMemoryLshTable(Some(testPrefix))
 
-      val redisServer = new RedisServer(1234)
-      redisServer.start()
+      val entry1 = LshEntry(testKey, "point1", DenseVector(0.1, 0.2))
+      val entry2 = LshEntry(testKey, "point2", DenseVector(0.3, 0.4))
+      table.put(entry1)
+      table.put(entry2)
 
-      val redis = new RedisClient("localhost", 1234, 5)
-      redis.flushdb
+      table.get(entry1.hash).length should equal(2)
 
-      val table = new RedisLshTable(redis, Some(testPrefix))
-
-      table.put(testKey, testLabel1, testPoint1)
-      table.put(testKey, testLabel2, testPoint2)
-      table.get(testKey).length should equal(2)
-      val data = table.get(testKey).sortBy(_._1)
-      data(0) should equal(testLabel1, testPrefix + ":" + testKey, testPoint1)
-      data(1) should equal(testLabel2, testPrefix + ":" + testKey, testPoint2)
-
-      redisServer.stop()
+      val expected1 = entry1.copy(hash = s"${testPrefix}:${testKey}")
+      val expected2 = entry2.copy(hash = s"${testPrefix}:${testKey}")
+      val data = table.get(testKey).sortBy(_.hash)
+      data should contain(expected1)
+      data should contain(expected2)
     }
   }
 
   describe("update") {
     it("should change the value previously stored") {
+      val testPrefix = "testprefix"
+      val table = new InMemoryLshTable(Some(testPrefix))
 
-      val testPoint = DenseVector(0.1, 0.2)
-      val testUpdatedPoint = DenseVector(0.3, 0.4)
-      val testKey1 = "testkey1"
-      val testKey2 = "testkey2"
-      val testPrefix = "testPrefix"
-      val testLabel = "testData"
+      val input = LshEntry("testkey1", "testData", DenseVector(0.1, 0.2))
+      table.put(input)
+      val expectedPut = input.copy(hash = s"${testPrefix}:${input.hash}")
+      val putResults = table.get(input.hash)
+      putResults.length should equal(1)
+      putResults.head should equal(expectedPut)
 
-      val redisServer = new RedisServer(1234)
-      redisServer.start()
+      val update = LshEntry("testkey2", input.label, DenseVector(0.3, 0.3))
+      table.update(update)
 
-      val redis = new RedisClient("localhost", 1234, 5)
-      redis.flushdb
+      table
+        .get(input.hash)
+        .length shouldBe 0 // make sure the original value has been updated
 
-      val table = new RedisLshTable(redis, Some(testPrefix))
-
-      table.put(testKey1, testLabel, testPoint)
-      table.get(testKey1).length should equal(1)
-      table.get(testKey1)(0) should equal(
-        testLabel,
-        testPrefix + ":" + testKey1,
-        testPoint
-      )
-
-      table.update(testKey2, testLabel, testUpdatedPoint)
-      table.get(testKey1).length should equal(0)
-      table.get(testKey2).length should equal(1)
-      table.get(testKey2)(0) should equal(
-        testLabel,
-        testPrefix + ":" + testKey2,
-        testUpdatedPoint
-      )
-
-      redisServer.stop()
+      val expectedUpdate = update.copy(hash = s"${testPrefix}:${update.hash}")
+      val updateResults = table.get(update.hash)
+      updateResults.length shouldBe 1
+      updateResults.head shouldBe expectedUpdate
     }
+  }
+
+  private def newClient(): RedisClient = {
+    new RedisClient("localhost", 1234, redisDb)
   }
 }


### PR DESCRIPTION
Scala 2.11 is still supported, you can build and test with both versions using `sbt +compile` and `sbt +test`